### PR TITLE
Adds histogramvec

### DIFF
--- a/histogram/histogram.go
+++ b/histogram/histogram.go
@@ -1,5 +1,5 @@
 // Package histogram provides primitives for working with histograms,
-// particularly towards Prometheus exporters.
+// particularly towards building Prometheus exporters.
 package histogram
 
 import (
@@ -26,7 +26,7 @@ type Histogram struct {
 
 func New(config Config) (*Histogram, error) {
 	if len(config.BucketLimits) == 0 {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Buckets must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "%T.BucketLimits must not be empty", config)
 	}
 
 	buckets := map[float64]uint64{}

--- a/histogramvec/error.go
+++ b/histogramvec/error.go
@@ -1,0 +1,14 @@
+package histogramvec
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/histogramvec/histogramvec.go
+++ b/histogramvec/histogramvec.go
@@ -1,0 +1,83 @@
+// Package histogramvec provides primitives for working with a vector of histograms,
+// particularly towards building Prometheus exporters.
+package histogramvec
+
+import (
+	"github.com/giantswarm/exporterkit/histogram"
+	"github.com/giantswarm/microerror"
+)
+
+type Config struct {
+	// BucketLimits is the upper limit of each bucket used when creating new internal Histograms.
+	// See https://godoc.org/github.com/prometheus/client_golang/prometheus#HistogramOpts.
+	BucketLimits []float64
+}
+
+// HistogramVec is a data structure suitable for holding multiple Histograms,
+// and then providing the inputs to multiple Prometheus Histograms.
+// See https://godoc.org/github.com/prometheus/client_golang/prometheus#MustNewConstHistogram.
+type HistogramVec struct {
+	// bucketLimits is the upper limit of buckets for the Histograms that the HistogramVec manages.
+	bucketLimits []float64
+
+	// histograms is a mapping between labels and the Histograms that the HistogramVec manages.
+	histograms map[string]*histogram.Histogram
+}
+
+func New(config Config) (*HistogramVec, error) {
+	if len(config.BucketLimits) == 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.BucketLimits must not be empty", config)
+	}
+
+	hv := &HistogramVec{
+		bucketLimits: config.BucketLimits,
+
+		histograms: map[string]*histogram.Histogram{},
+	}
+
+	return hv, nil
+}
+
+// Add saves an entry to the Histogram with the given label,
+// creating it internally if required.
+func (hv *HistogramVec) Add(label string, x float64) error {
+	if _, ok := hv.histograms[label]; !ok {
+		c := histogram.Config{
+			BucketLimits: hv.bucketLimits,
+		}
+
+		h, err := histogram.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		hv.histograms[label] = h
+	}
+
+	hv.histograms[label].Add(x)
+
+	return nil
+}
+
+// Ensure removes any internal Histograms that aren't in the given slice of labels.
+// This is useful when a label is no longer being recorded, such as in dynamic systems.
+func (hv *HistogramVec) Ensure(labels []string) {
+	for existingLabel := range hv.histograms {
+		labelRequested := false
+
+		for _, requestedLabel := range labels {
+			if requestedLabel == existingLabel {
+				labelRequested = true
+			}
+		}
+
+		if !labelRequested {
+			delete(hv.histograms, existingLabel)
+		}
+	}
+}
+
+// Histograms returns the currently managed Histograms.
+func (hv *HistogramVec) Histograms() map[string]*histogram.Histogram {
+	return hv.histograms
+}

--- a/histogramvec/histogramvec_test.go
+++ b/histogramvec/histogramvec_test.go
@@ -1,0 +1,331 @@
+package histogramvec
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func Example() {
+	// Create a new descriptor with a label.
+	desc := prometheus.NewDesc(
+		"fridge_temperature_celsius",
+		"The temperature of the fridge in each store",
+		[]string{"store_name"},
+		nil,
+	)
+
+	// Create a HistogramVec.
+	c := Config{
+		BucketLimits: []float64{0, 1, 2, 3, 4, 5},
+	}
+	hv, _ := New(c)
+
+	// Define a struct to hold sensor data,
+	// here, the temperature of each store's refrigerator.
+	type StoreTemperature struct {
+		StoreName   string
+		Temperature float64
+	}
+
+	// Read data from an external system.
+	firstSamples := []StoreTemperature{
+		{
+			StoreName:   "London",
+			Temperature: 2.5,
+		},
+		{
+			StoreName:   "Frankfurt",
+			Temperature: 3.2,
+		},
+	}
+
+	// Add the samples to the HistogramVec.
+	for _, s := range firstSamples {
+		hv.Add(s.StoreName, s.Temperature)
+	}
+
+	// Emit each metric, such as in a Prometheus Collector.
+	// This will emit Histograms for both the London and Frankfurt stores.
+	for label, h := range hv.Histograms() {
+		metric := prometheus.MustNewConstHistogram(
+			desc,
+			h.Count(), h.Sum(), h.Buckets(),
+			label,
+		)
+
+		fmt.Println(metric)
+	}
+
+	// Read data again from an external system.
+	// For example, this would be a separate invocation of Collect
+	// in a Prometheus Collector.
+	secondSamples := []StoreTemperature{
+		{
+			StoreName:   "London",
+			Temperature: 2.6,
+		},
+		// Note: Frankfurt store has shut down,
+		// and does not report fridge temperatures anymore.
+	}
+
+	// Add the second set of sample to the HistogramVec.
+	for _, s := range secondSamples {
+		hv.Add(s.StoreName, s.Temperature)
+	}
+
+	// Ensure that any stores that have shut down are removed from the HistogramVec.
+	// This should be done on every sampling (ommitted earlier for clarity).
+	storeNames := []string{}
+	for _, s := range secondSamples {
+		storeNames = append(storeNames, s.StoreName)
+	}
+	hv.Ensure(storeNames)
+
+	// Again, emit each metric. This will only emit a Histogram for the London store,
+	// as the Frankfurt store has been removed.
+	for label, h := range hv.Histograms() {
+		metric := prometheus.MustNewConstHistogram(
+			desc,
+			h.Count(), h.Sum(), h.Buckets(),
+			label,
+		)
+
+		fmt.Println(metric)
+	}
+}
+
+func Test_Add(t *testing.T) {
+	type addInput struct {
+		label  string
+		sample float64
+	}
+	type histogram struct {
+		count   uint64
+		sum     float64
+		buckets map[float64]uint64
+	}
+
+	testCases := []struct {
+		name               string
+		config             Config
+		addInput           []addInput
+		expectedHistograms map[string]histogram
+	}{
+		{
+			name: "case 0: Add 1 input to histogramvec",
+			config: Config{
+				BucketLimits: []float64{5},
+			},
+			addInput: []addInput{
+				{
+					label:  "foo",
+					sample: 1,
+				},
+			},
+			expectedHistograms: map[string]histogram{
+				"foo": {
+					count: 1,
+					sum:   1,
+					buckets: map[float64]uint64{
+						5: 1,
+					},
+				},
+			},
+		},
+
+		{
+			name: "case 1: Add 2 differently labelled inputs",
+			config: Config{
+				BucketLimits: []float64{5},
+			},
+			addInput: []addInput{
+				{
+					label:  "foo",
+					sample: 1,
+				},
+				{
+					label:  "bar",
+					sample: 2,
+				},
+			},
+			expectedHistograms: map[string]histogram{
+				"foo": {
+					count: 1,
+					sum:   1,
+					buckets: map[float64]uint64{
+						5: 1,
+					},
+				},
+				"bar": {
+					count: 1,
+					sum:   2,
+					buckets: map[float64]uint64{
+						5: 1,
+					},
+				},
+			},
+		},
+
+		{
+			name: "case 3: Add multiple inputs to same histogram",
+			config: Config{
+				BucketLimits: []float64{5},
+			},
+			addInput: []addInput{
+				{
+					label:  "foo",
+					sample: 1,
+				},
+				{
+					label:  "bar",
+					sample: 2,
+				},
+				{
+					label:  "foo",
+					sample: 2,
+				},
+			},
+			expectedHistograms: map[string]histogram{
+				"foo": {
+					count: 2,
+					sum:   3,
+					buckets: map[float64]uint64{
+						5: 2,
+					},
+				},
+				"bar": {
+					count: 1,
+					sum:   2,
+					buckets: map[float64]uint64{
+						5: 1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hv, err := New(tc.config)
+			if err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+
+			for _, x := range tc.addInput {
+				if err := hv.Add(x.label, x.sample); err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+			}
+
+			hs := hv.Histograms()
+			returnedHistograms := map[string]histogram{}
+
+			for label, h := range hs {
+				returnedHistograms[label] = histogram{
+					count:   h.Count(),
+					sum:     h.Sum(),
+					buckets: h.Buckets(),
+				}
+			}
+
+			if !reflect.DeepEqual(returnedHistograms, tc.expectedHistograms) {
+				t.Fatalf("histograms == %v, want %v", returnedHistograms, tc.expectedHistograms)
+			}
+		})
+	}
+}
+
+func Test_Ensure(t *testing.T) {
+	type addInput struct {
+		label  string
+		sample float64
+	}
+
+	testCases := []struct {
+		name           string
+		config         Config
+		addInput       []addInput
+		ensureLabels   []string
+		expectedLabels []string
+	}{
+		{
+			name: "case 0: Ensure no labels exist",
+			config: Config{
+				BucketLimits: []float64{5},
+			},
+			addInput: []addInput{
+				{
+					label:  "foo",
+					sample: 1,
+				},
+			},
+			ensureLabels:   []string{},
+			expectedLabels: []string{},
+		},
+
+		{
+			name: "case 1: Ensure 1 label exists",
+			config: Config{
+				BucketLimits: []float64{5},
+			},
+			addInput: []addInput{
+				{
+					label:  "foo",
+					sample: 1,
+				},
+			},
+			ensureLabels:   []string{"foo"},
+			expectedLabels: []string{"foo"},
+		},
+
+		{
+			name: "case 2: Ensure 1 label out of 2 exists",
+			config: Config{
+				BucketLimits: []float64{5},
+			},
+			addInput: []addInput{
+				{
+					label:  "foo",
+					sample: 1,
+				},
+				{
+					label:  "bar",
+					sample: 1,
+				},
+			},
+			ensureLabels:   []string{"foo"},
+			expectedLabels: []string{"foo"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hv, err := New(tc.config)
+			if err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+
+			for _, x := range tc.addInput {
+				if err := hv.Add(x.label, x.sample); err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+			}
+
+			hv.Ensure(tc.ensureLabels)
+
+			hs := hv.Histograms()
+
+			returnedLabels := []string{}
+			for label, _ := range hs {
+				returnedLabels = append(returnedLabels, label)
+			}
+
+			if !reflect.DeepEqual(returnedLabels, tc.expectedLabels) {
+				t.Fatalf("labels == %v, want %v", returnedLabels, tc.expectedLabels)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3711

This adds a `HistogramVec` struct, which can be used to manage multiple `Histogram`s at a time. This is useful in the case that you are providing metrics for a Prometheus `HistogramVec`, such as monitoring latency for network calls.