### PR TITLE
Moves histogram count to int32

### DIFF
--- a/histogram/histogram.go
+++ b/histogram/histogram.go
@@ -18,12 +18,12 @@ type Config struct {
 // See https://godoc.org/github.com/prometheus/client_golang/prometheus#MustNewConstHistogram.
 type Histogram struct {
 	// count is the number of entries added to the Histogram.
-	count uint64
+	count int32
 	// sum is the total sum of all entries added to the Histogram.
 	sum float64
 	// buckets is a map of upper bounds to cumulative counts of entries,
 	// excluding the +Inf bucket.
-	buckets map[float64]uint64
+	buckets map[float64]int32
 	// mutex controls access to the buckets map, to allow for safe concurrent access.
 	mutex sync.Mutex
 }
@@ -33,7 +33,7 @@ func New(config Config) (*Histogram, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.BucketLimits must not be empty", config)
 	}
 
-	buckets := map[float64]uint64{}
+	buckets := map[float64]int32{}
 	for _, bucketLimit := range config.BucketLimits {
 		buckets[bucketLimit] = 0
 	}
@@ -62,7 +62,7 @@ func (h *Histogram) Add(x float64) {
 
 // Count returns the number of samples recorded.
 func (h *Histogram) Count() uint64 {
-	return h.count
+	return uint64(h.count)
 }
 
 // Buckets returns the sum of all samples recorded.
@@ -78,7 +78,7 @@ func (h *Histogram) Buckets() map[float64]uint64 {
 	bucketsCopy := map[float64]uint64{}
 
 	for value, count := range h.buckets {
-		bucketsCopy[value] = count
+		bucketsCopy[value] = uint64(count)
 	}
 
 	return bucketsCopy

--- a/histogram/histogram.go
+++ b/histogram/histogram.go
@@ -18,12 +18,12 @@ type Config struct {
 // See https://godoc.org/github.com/prometheus/client_golang/prometheus#MustNewConstHistogram.
 type Histogram struct {
 	// count is the number of entries added to the Histogram.
-	count int32
+	count uint32
 	// sum is the total sum of all entries added to the Histogram.
 	sum float64
 	// buckets is a map of upper bounds to cumulative counts of entries,
 	// excluding the +Inf bucket.
-	buckets map[float64]int32
+	buckets map[float64]uint32
 	// mutex controls access to the buckets map, to allow for safe concurrent access.
 	mutex sync.Mutex
 }
@@ -33,7 +33,7 @@ func New(config Config) (*Histogram, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.BucketLimits must not be empty", config)
 	}
 
-	buckets := map[float64]int32{}
+	buckets := map[float64]uint32{}
 	for _, bucketLimit := range config.BucketLimits {
 		buckets[bucketLimit] = 0
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6130

We use a 64 bit int to store the number of observations in a bucket,
which is excessive for number of occurrences in a bucket.
Changing to int32 helps reduce memory usage, as we use a number
of histograms (e.g: w/ histogramvec) in some projects.