### PR TITLE
Use micrologger v0.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,15 +18,15 @@
   version = "v1.4.7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bcf7cab60e36c24a5f655b723befdff105cef16c0c95b23e1c6da0d33d4c900c"
+  branch = "go-modules"
+  digest = "1:9dcf61abc3db8f360cb7a1b54f63a371ad49f7b18ba68eadd2308841652674ab"
   name = "github.com/giantswarm/microendpoint"
   packages = [
     "endpoint/healthz",
     "service/healthz",
   ]
   pruneopts = "UT"
-  revision = "f77c569259aef9cea5e38d0d7d94bf1d7d07d136"
+  revision = "c2c5b3af4bdbf26b692c037bd5e9e6db21a64fd5"
 
 [[projects]]
   branch = "master"
@@ -37,19 +37,18 @@
   revision = "3bc3cb1a36700aa4bbfcf6c335bc2ab92ad66d8d"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ae978037ecf0a99551443cd0138943efb5f0549c5ea890251c6ead61dccfe25b"
+  branch = "micrologger-0-1-0"
+  digest = "1:133a7905737f10fdc816766812b29fa33f554afb4d9d1101f74cf425add9ebf8"
   name = "github.com/giantswarm/microkit"
   packages = [
     "server",
     "tls",
   ]
   pruneopts = "UT"
-  revision = "ae70e65c60f81ba9442376702b7666b261a1895a"
+  revision = "7c0ae67f84b119e006019d2d23bc8bb99d6b3454"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4ddd1df6c63413a6686c91013ff2d7646fd0a51f507c820c87dd1be419abaadc"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -57,7 +56,8 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "22dc3b5565d150e1f94fbed50df3baf6cd40fac9"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:83a37f3bd4ccd13469775ef771e943e6c7cfaba6926decff6c83135e56512f08"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,11 +31,11 @@
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  branch = "micrologger-0-1-0"
   name = "github.com/giantswarm/microkit"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.1.0"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/microendpoint/LICENSE
+++ b/vendor/github.com/giantswarm/microendpoint/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/error.go
+++ b/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/error.go
@@ -4,14 +4,18 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-var invalidConfigError = microerror.New("invalid config")
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
 
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var wrongTypeError = microerror.New("wrong type")
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
 
 // IsWrongType asserts wrongTypeError.
 func IsWrongType(err error) bool {

--- a/vendor/github.com/giantswarm/microkit/server/codes.go
+++ b/vendor/github.com/giantswarm/microkit/server/codes.go
@@ -7,6 +7,8 @@ var (
 	CodeFailure = "FAILURE"
 	// CodeInvalidCredentials indicates the provided credentials are not valid.
 	CodeInvalidCredentials = "INVALID_CREDENTIALS"
+	// CodeNotSupported indicates that the resource is not supported.
+	CodeNotSupported = "NOT_SUPPORTED"
 	// CodePermissionDenied indicates the provided credentials are valid, but the
 	// requested resource requires other permissions.
 	CodePermissionDenied = "PERMISSION_DENIED"

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] 2020-02-13
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/micrologger/DCO
+++ b/vendor/github.com/giantswarm/micrologger/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.lock
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.lock
@@ -3,43 +3,74 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:9c432418e5180be62a4bf565761eb2c618fc4ff9b7efa9a260c92068f453e28a"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
+  pruneopts = ""
   revision = "a8d5d4f526c526b4b773062958847fe7e0b7f449"
 
 [[projects]]
+  digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"
   name = "github.com/go-kit/kit"
   packages = ["log"]
+  pruneopts = ""
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
 [[projects]]
+  digest = "1:6a4a01d58b227c4b6b11111b9f172ec5c17682b82724e58e6daf3f19f4faccd8"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:9ca737b471693542351e112c9e86be9bf7385e42256893a09ecb2a98e2036f74"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = ""
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
+  digest = "1:9fcb267c272bc5054564b392e3ff7e65e35400fd9914afb1d169f92b95e7dbc9"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = ""
+  revision = "2d0692c2e9617365a95b295612ac0d4415ba4627"
+  version = "v0.3.1"
+
+[[projects]]
   branch = "master"
+  digest = "1:6a3c12156fd310ad95e3fe38070b1bf74e123552e374f1a57a188682a96d168e"
   name = "github.com/juju/errgo"
   packages = ["."]
+  pruneopts = ""
   revision = "08cceb5d0b5331634b9826762a8fd53b29b86ad8"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2adbe8d5ab3a48cdea1da27b9657857aa30d8758cead74b25c92eaa5be867f09"
+  input-imports = [
+    "github.com/giantswarm/microerror",
+    "github.com/go-kit/kit/log",
+    "github.com/go-stack/stack",
+    "github.com/google/go-cmp/cmp",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.toml
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.toml
@@ -32,3 +32,7 @@
 [[constraint]]
   name = "github.com/go-stack/stack"
   version = "1.7.0"
+
+[[constraint]]
+  name = "github.com/google/go-cmp"
+  version = "0.3.1"

--- a/vendor/github.com/giantswarm/micrologger/LICENSE
+++ b/vendor/github.com/giantswarm/micrologger/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/giantswarm/micrologger/README.md
+++ b/vendor/github.com/giantswarm/micrologger/README.md
@@ -1,8 +1,8 @@
+[![CircleCI](https://circleci.com/gh/giantswarm/micrologger.svg?style=shield)](https://circleci.com/gh/giantswarm/micrologger)
+[![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/micrologger)](https://goreportcard.com/report/github.com/giantswarm/micrologger)
+[![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#giantswarm)
+
 # micrologger
 
-[![CircleCI](https://circleci.com/gh/giantswarm/micrologger.svg?style=svg)](https://circleci.com/gh/giantswarm/micrologger) [![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/micrologger)](https://goreportcard.com/report/github.com/giantswarm/micrologger) [![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#giantswarm)
-
-This is a logging library we use at Giant Swarm for many of our operators and microservices.
-
-[GoDoc](https://godoc.org/github.com/giantswarm/micrologger)
-
+This is a logging library we use at Giant Swarm for many of our operators and
+microservices.

--- a/vendor/github.com/giantswarm/micrologger/activation_logger.go
+++ b/vendor/github.com/giantswarm/micrologger/activation_logger.go
@@ -112,25 +112,14 @@ func (l *activationLogger) With(keyVals ...interface{}) Logger {
 	return l.underlying.With(keyVals...)
 }
 
-func containsKey(keyVals []interface{}, aKey string) bool {
-	for i := 0; i < len(keyVals); i += 2 {
-		s, ok := keyVals[i].(string)
-		if ok && s == aKey {
-			return true
-		}
-	}
-
-	return false
-}
-
-func containsVal(keyVals []interface{}, aVal interface{}) bool {
+func valueFor(keyVals []interface{}, key string) (interface{}, bool) {
 	for i := 1; i < len(keyVals); i += 2 {
-		if keyVals[i] == aVal {
-			return true
+		if key == keyVals[i-1] {
+			return keyVals[i], true
 		}
 	}
 
-	return false
+	return nil, false
 }
 
 func isLevelAllowed(keyVals []interface{}, aVal interface{}) bool {
@@ -195,7 +184,8 @@ func shouldActivate(activations map[string]interface{}, keyVals []interface{}) (
 	var activationCount int
 
 	for aKey, aVal := range activations {
-		if containsKey(keyVals, aKey) && containsVal(keyVals, aVal) {
+		v, ok := valueFor(keyVals, aKey)
+		if ok && v == aVal {
 			activationCount++
 			continue
 		}

--- a/vendor/github.com/giantswarm/micrologger/microloggertest/logger.go
+++ b/vendor/github.com/giantswarm/micrologger/microloggertest/logger.go
@@ -1,16 +1,12 @@
 package microloggertest
 
 import (
-	"io/ioutil"
-
 	"github.com/giantswarm/micrologger"
 )
 
-// New returns a Logger intance configured to discard its output.
+// New returns a Logger intance or panics if the creation fails.
 func New() micrologger.Logger {
-	c := micrologger.Config{
-		IOWriter: ioutil.Discard,
-	}
+	c := micrologger.Config{}
 
 	logger, err := micrologger.New(c)
 	if err != nil {


### PR DESCRIPTION
We need to pin the micrologger dependency to the v0.1.0 version which is the one using dep instead of newer versions that use go modules.

