### PR TITLE
Reduce verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
 
+- Stop logging debug messages when metrics are collected.
 
 ## [0.2.0] 2020-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+### Fixed
 
-- Stop logging debug messages when metrics are collected.
+- Reduce noisy debug logging when metrics are collected.
 
 ## [0.2.0] 2020-03-23
 

--- a/collector/set.go
+++ b/collector/set.go
@@ -70,8 +70,6 @@ func (s *Set) Boot(ctx context.Context) error {
 }
 
 func (s *Set) Collect(ch chan<- prometheus.Metric) {
-	s.logger.Log("level", "debug", "message", "collecting metrics")
-
 	var g errgroup.Group
 
 	for _, item := range s.collectors {
@@ -91,8 +89,6 @@ func (s *Set) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		s.logger.Log("level", "error", "message", "failed collecting metrics", "stack", fmt.Sprintf("%#v", microerror.Mask(err)))
 	}
-
-	s.logger.Log("level", "debug", "message", "collected metrics")
 }
 
 func (s *Set) Describe(ch chan<- *prometheus.Desc) {


### PR DESCRIPTION
`exporterkit` is currently generating unhelpful noise in our operator logs like:

```
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:73","level":"debug","message":"collecting metrics","time":"2020-11-10T21:46:30.00733+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:73","level":"debug","message":"collecting metrics","time":"2020-11-10T21:46:30.007337+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:73","level":"debug","message":"collecting metrics","time":"2020-11-10T21:46:30.008315+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:73","level":"debug","message":"collecting metrics","time":"2020-11-10T21:46:30.008347+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:95","level":"debug","message":"collected metrics","time":"2020-11-10T21:46:30.039539+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:95","level":"debug","message":"collected metrics","time":"2020-11-10T21:46:30.049381+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:95","level":"debug","message":"collected metrics","time":"2020-11-10T21:46:31.02203+00:00"}
{"caller":"github.com/giantswarm/exporterkit/collector/set.go:95","level":"debug","message":"collected metrics","time":"2020-11-10T21:46:31.02666+00:00"}
```

Discussed in SIG Operator that it makes sense to remove https://gigantic.slack.com/archives/C2MS2VB37/p1602588997052800

## Checklist

- [x] Update changelog in CHANGELOG.md.
