### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] 2021-02-08
+
 ### Added
 
 - Add `Set.Stop` method to stop collector after is has been booted.
@@ -34,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-[Unreleased]: https://github.com/giantswarm/exporterkit/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/giantswarm/exporterkit/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/giantswarm/exporterkit/compare/v0.1.0...v0.2.0
 [0.2.0]: https://github.com/giantswarm/exporterkit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/giantswarm/exporterkit/releases/tag/v0.1.0


### PR DESCRIPTION
### Added

- Add `Set.Stop` method to stop collector after is has been booted.

### Fixed

- Reduce noisy debug logging when metrics are collected.