### PR TITLE
Add ExtraEndpoints configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ExtraEndpoints configuration.
+
 ## [1.1.0] - 2023-11-09
 
 ### Changed


### PR DESCRIPTION
I'm intending to use it to add extra `/blackbox` endpoint to `net-exporter`. This is going to be exposed to the internet and scraped with `blackbox_exporter` and used for ingress SLO/SLA metrics.

Initially we wanted to use `/healthz` but apparently `ingress-nginx` responds to `/healthz` with the default backend and yes it would be ok to use it but this solution wouldn't be generic and we wouldn't be able to reuse for other ingress implementation (e.g. `kong`).